### PR TITLE
Features: create Csv_upload blueprint and templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ ailerons_tracker_backend.egg-info/
 .devcontainer/
 uploaded_csv/*.csv
 **/.DS_Store
-node_modules/*
 stylintrc.json
+node_modules/
+

--- a/ailerons_tracker_backend/blueprints/csv_upload.py
+++ b/ailerons_tracker_backend/blueprints/csv_upload.py
@@ -1,0 +1,76 @@
+""" Upload CSV files blueprint """
+
+import uuid
+import postgrest
+from flask_htmx import HTMX, make_response
+from jinja_partials import render_partial
+from flask import Blueprint, abort, flash, render_template, request, current_app
+from jinja2 import TemplateNotFound
+from ailerons_tracker_backend.clients.supabase_client import supabase
+from ailerons_tracker_backend.csv_parser.csv_parser import CsvParser
+from ailerons_tracker_backend.errors import GeneratorError, InvalidFile
+from ailerons_tracker_backend.utils.file_util import FileManager
+
+csv_upload = Blueprint('csv_upload', __name__,
+                       template_folder='templates')
+
+
+@csv_upload.post('/upload')
+def upload_file():
+    """ Parse a CSV file and insert data in DB """
+
+    try:
+        # On récupère le nom/id de l'individu auquel correspondent les fichiers
+        associated_individual = request.args.get("id")
+
+        current_app.logger.warning(associated_individual)
+
+        csv_uuid = str(uuid.uuid4())
+        file_manager = FileManager(request, csv_uuid)
+        csv_parser = CsvParser(file_manager)
+
+        supabase.create_csv_log(
+            csv_uuid, file_manager.loc_file.name, file_manager.depth_file.name)
+
+        supabase.batch_insert("record", csv_parser.record_list)
+
+        file_manager.drop_all()
+
+        return make_response(render_partial('dashboard/dashboard.jina'), push_url='/dashboard'), 200
+
+    # Erreur supabase
+    except postgrest.exceptions.APIError as e:
+        current_app.logger.error(e.message)
+        return e.message, 304
+
+    except GeneratorError as e:
+        current_app.logger.error(e.message)
+        return e.message, 500
+
+    except InvalidFile as e:
+        current_app.logger.error(e.message)
+        return e.message, 400
+
+
+@csv_upload.get('/csv_upload')
+def show():
+    """ Serve csv upload page """
+    try:
+        htmx = HTMX(current_app)
+
+        individual_id = request.args.get('id')
+
+        individual_data = supabase.get_exact(
+            'id', individual_id, "individual")
+        # Render template returns raw HTML
+        if (htmx):
+            return make_response(
+                render_partial('csv_upload/csv_upload.jinja',
+                               ind=individual_data),
+                replace_url=f'/portal/csv_upload?id={individual_id}')
+
+        return render_template('base_layout.jinja')
+
+    except TemplateNotFound as e:
+        current_app.logger.warning(e)
+        abort(404)

--- a/ailerons_tracker_backend/blueprints/csv_upload.py
+++ b/ailerons_tracker_backend/blueprints/csv_upload.py
@@ -36,7 +36,7 @@ def upload_file():
 
         file_manager.drop_all()
 
-        return make_response(render_partial('dashboard/dashboard.jina'), push_url='/dashboard'), 200
+        return make_response(render_partial('dashboard/dashboard.jinja'), push_url='/dashboard'), 200
 
     # Erreur supabase
     except postgrest.exceptions.APIError as e:

--- a/ailerons_tracker_backend/blueprints/dashboard.py
+++ b/ailerons_tracker_backend/blueprints/dashboard.py
@@ -1,6 +1,6 @@
 """ Dashboard blueprint """
 
-from flask_htmx import HTMX
+from flask_htmx import HTMX, make_response
 from jinja_partials import render_partial
 from flask import Blueprint, render_template, abort, current_app
 from jinja2 import TemplateNotFound
@@ -18,10 +18,12 @@ def show():
         individuals = supabase.get_all('individual')
 
         if htmx:
-            return render_partial('dashboard/dashboard.jinja', inds=individuals)
+            return make_response(
+                render_partial('dashboard/dashboard.jinja', inds=individuals),
+            replace_url='/portal/dashboard')
 
         return render_template('base_layout.jinja')
-    
+
     except TemplateNotFound as e:
         current_app.logger.warning(e)
         abort(404)

--- a/ailerons_tracker_backend/blueprints/portal.py
+++ b/ailerons_tracker_backend/blueprints/portal.py
@@ -3,11 +3,13 @@
 from flask import Blueprint, abort, current_app, render_template
 from jinja2 import TemplateNotFound
 from ailerons_tracker_backend.blueprints.dashboard import dashboard
+from ailerons_tracker_backend.blueprints.csv_upload import csv_upload
 
 portal = Blueprint('portal', __name__,
                    template_folder='templates', static_folder='static', url_prefix='/portal')
 
 portal.register_blueprint(dashboard)
+portal.register_blueprint(csv_upload)
 
 
 @portal.route('/')

--- a/ailerons_tracker_backend/clients/supabase_client.py
+++ b/ailerons_tracker_backend/clients/supabase_client.py
@@ -36,6 +36,13 @@ class SupabaseClient:
             "*").eq(col, matcher).execute()
         return res.data
 
+    def get_exact(self, col: str, matcher: str, table: str):
+        """ Get specific row from table where primary key matches provided value """
+
+        res = self._client.table(table).select(
+            "*").eq(col, matcher).execute()
+        return res.data[0]
+
     def upsert(self, obj: object, table: str):
         """ Insert or update a row in selected table """
 
@@ -46,12 +53,12 @@ class SupabaseClient:
 
     def create_csv_log(self, uuid: str, loc_file_name: str, depth_file_name: str):
         """ Create and insert a CSV log in the DB and returns the generated ID """
-        csv_log = { 'uuid': uuid,
+        csv_log = {'uuid': uuid,
                    'loc_file': loc_file_name,
-                    'depth_file': depth_file_name }
+                   'depth_file': depth_file_name}
         data = self._client.table('csv').insert(csv_log).execute()
         content = data.__dict__.get('data')[0]
-        
+        return content
 
     def batch_insert(self, table: str, datalist: list):
         """ Batch insert new rows in table Record """

--- a/ailerons_tracker_backend/templates/csv_upload/csv_upload.jinja
+++ b/ailerons_tracker_backend/templates/csv_upload/csv_upload.jinja
@@ -1,0 +1,16 @@
+<section id="csv-upload-section">
+  <h2>Envoyer des fichiers</h2>
+  <hr />
+  <form id="csv-upload-form"
+        hx-post="upload?id={{ ind.id }}"
+        hx-encoding="multipart/form-data"
+        hx-target="main"
+        hx-swap="innerHTML swap:300ms settle:50ms show:window:top">
+    {{ render_partial('shared/inputs/file.jinja', input_id='loc_file', label='Relevés de localisation', accept='.csv') }}
+    {{ render_partial('shared/inputs/file.jinja', input_id='depth_file' , label='Relevés de profondeur',accept='.csv') }}
+    <div class="row-wrapper padded">
+      {{ render_partial('shared/cancel_button.jinja', action='dashboard') }}
+      <input type="submit" class="submit" />
+    </div>
+  </form>
+</section>

--- a/ailerons_tracker_backend/templates/dashboard/partials/individual_row.jinja
+++ b/ailerons_tracker_backend/templates/dashboard/partials/individual_row.jinja
@@ -18,6 +18,10 @@
     </td>
     <td class="action">
         <button class="edit">Editer</button>
-        <button class="upload">Upload</button>
+        <button class="upload"
+                hx-get="/portal/csv_upload?id={{ ind.id }}"
+                hx-trigger="click"
+                hx-target="main"
+                hx-swap="innerHTML swap:300ms settle:50ms show:window:top">Upload</button>
     </td>
 </tr>

--- a/ailerons_tracker_backend/templates/shared/cancel_button.jinja
+++ b/ailerons_tracker_backend/templates/shared/cancel_button.jinja
@@ -1,0 +1,5 @@
+<button class="cancel"
+        hx-get="{{ action }}"
+        hx-trigger="click"
+        hx-target="main"
+        hx-swap="innerHTML swap:300ms settle:50ms show:window:top">Annuler</button>

--- a/ailerons_tracker_backend/templates/shared/inputs/checkbox.jinja
+++ b/ailerons_tracker_backend/templates/shared/inputs/checkbox.jinja
@@ -1,0 +1,8 @@
+<label class="horizontal grow" for="{{ input_id }}">
+    {{ label }}
+    <input type="checkbox"
+           class="check"
+           id="{{ input_id }}"
+           name="{{ input_id }}"
+           {% if val: %}value="{{ val }}"{% endif %} />
+</label>

--- a/ailerons_tracker_backend/templates/shared/inputs/date.jinja
+++ b/ailerons_tracker_backend/templates/shared/inputs/date.jinja
@@ -1,0 +1,8 @@
+<label for="{{ input_id }}">
+  {{ label }}
+  <input type="date"
+         class="date"
+         id="{{ input_id }}"
+         name="{{ input_id }}"
+         value="{{ val }}" />
+</label>

--- a/ailerons_tracker_backend/templates/shared/inputs/datetime.jinja
+++ b/ailerons_tracker_backend/templates/shared/inputs/datetime.jinja
@@ -1,0 +1,8 @@
+<label for="{{ input_id }}">
+  {{ label }}
+  <input type="datetime-local"
+         class="date"
+         id="{{ input_id }}"
+         name="{{ input_id }}"
+         value="{{ val }}" />
+</label>

--- a/ailerons_tracker_backend/templates/shared/inputs/file.jinja
+++ b/ailerons_tracker_backend/templates/shared/inputs/file.jinja
@@ -1,0 +1,8 @@
+<label for="{{ input_id }}">
+    {{ label }}
+    <input type="file"
+           class="file"
+           id="{{ input_id }}"
+           name="{{ input_id }}"
+           accept="{{ accept }}" />
+</label>

--- a/ailerons_tracker_backend/templates/shared/inputs/image_file.jinja
+++ b/ailerons_tracker_backend/templates/shared/inputs/image_file.jinja
@@ -1,0 +1,4 @@
+<label for="{{ input_id }}">
+  {{ label }}
+  <input type="file" class="file" id="{{ input_id }}" name="{{ input_id }}" accept=".png,.jpg" {% if multiple: %}{{ multiple }}{% endif %} {% if val: %}value="{{ val }}"{% endif %} />
+</label>

--- a/ailerons_tracker_backend/templates/shared/inputs/number.jinja
+++ b/ailerons_tracker_backend/templates/shared/inputs/number.jinja
@@ -1,0 +1,10 @@
+<label for="{{ input_id }}">
+    {{ label }}
+    <input type="number"
+           class="number"
+           id="{{ input_id }}"
+           name="{{ input_id }}"
+           min="{{ min }}"
+           max="{{ max }}"
+           value="{{ val }}" />
+</label>

--- a/ailerons_tracker_backend/templates/shared/inputs/option.jinja
+++ b/ailerons_tracker_backend/templates/shared/inputs/option.jinja
@@ -1,0 +1,5 @@
+{% if control == value: %}
+    <option value="{{ value }}" selected>{{ value }}</option>
+{% else: %}
+    <option value="{{ value }}">{{ value }}</option>
+{% endif %}

--- a/ailerons_tracker_backend/templates/shared/inputs/password.jinja
+++ b/ailerons_tracker_backend/templates/shared/inputs/password.jinja
@@ -1,0 +1,3 @@
+<label for="password">Mot de passe:
+    <input type="password" class="field" id="password" name="password" />
+</label>

--- a/ailerons_tracker_backend/templates/shared/inputs/radio.jinja
+++ b/ailerons_tracker_backend/templates/shared/inputs/radio.jinja
@@ -1,0 +1,17 @@
+<label class="horizontal" for="{{ input_id }}">
+    {{ label }}
+    {% if checked: %}
+        <input type="radio"
+               class="check"
+               id="{{ input_id }}"
+               name="{{ input_name }}"
+               value="{{ value }}"
+               checked="{{ checked }}" />
+    {% else: %}
+        <input type="radio"
+               class="check"
+               id="{{ input_id }}"
+               name="{{ input_name }}"
+               value="{{ value }}" />
+    {% endif %}
+</label>

--- a/ailerons_tracker_backend/templates/shared/inputs/select.jinja
+++ b/ailerons_tracker_backend/templates/shared/inputs/select.jinja
@@ -1,0 +1,9 @@
+<label for="{{ input_id }}">
+  {{ label }}
+  <select id="{{ input_id }}" name="{{ input_id }}">
+    {% for opt in options %}
+      {{ render_partial('shared/inputs/option.jinja',
+            value = opt, control = control) }}
+    {% endfor %}
+  </select>
+</label>

--- a/ailerons_tracker_backend/templates/shared/inputs/text.jinja
+++ b/ailerons_tracker_backend/templates/shared/inputs/text.jinja
@@ -1,0 +1,8 @@
+<label for="{{ input_id }}">
+  {{ label }}
+  <input type="text"
+         class="field"
+         id="{{ input_id }}"
+         name="{{ input_name }}"
+         value="{{ val }}" />
+</label>

--- a/ailerons_tracker_backend/templates/shared/inputs/textarea.jinja
+++ b/ailerons_tracker_backend/templates/shared/inputs/textarea.jinja
@@ -1,0 +1,6 @@
+<label for="{{ input_id }}">
+  {{ label }}
+  <textarea id="{{input_id}}" name="{{input_id}}" placeholder="{{placeholder}}">
+  {{ val }}
+  </textarea>
+</label>

--- a/tests/route_tests.py
+++ b/tests/route_tests.py
@@ -49,7 +49,7 @@ def test_individual_route(client):
 def test_upload_route(client):
     """ Test upload route by mocking a request """
 
-    response = client.post("/upload", data={
+    response = client.post("/portal/upload", data={
         "ind-select": 1,
         "loc_file": (resources / "test_upload_loc.csv").open("rb"),
         "depth_file": (resources / "test_upload_depth.csv").open("rb")})

--- a/tests/route_tests.py
+++ b/tests/route_tests.py
@@ -3,8 +3,6 @@
 import logging
 from pathlib import Path
 
-from flask import render_template
-
 resources = Path(__file__).parent / "resources"
 
 


### PR DESCRIPTION
## Création d'un blueprint dédié à la fonction de chargement de fichiers CSV, avec templates correspondants.

### **Ajouts:**
* **csv_upload.py** - Crée le blueprint avec les routes précedemment présentes dans *init.py*, modifiées pour retourner des templates
* **templates/shared/** - Crée plusieurs templates de composants (boutons, inputs) utilisant HTMX pour déclencher des requêtes et la navigation entre les vues
* **templates/csv_upload.jinja** - Vue permettant de charger des fichiers CSV, rattachée au blueprint _csv_upload.py_
*  **tests/route_tests.py** - Replace old csv_upload route by new route 'portal/csv_upload'

### **Modifications:**
* **init.py** - Supprime les routes liées à _csv_upload_
* **dashboard.py** - Modifie la route afin de créer une réponse permettant de "pousser" l'url qui lui correspond (portal/ -> portal/dashboard) et ainsi **permettre à l'utilisateur de rafraichir la page et améliorer la navigation**
* **portal.py** - Charge le blueprint "csv_upload" en tant que blueprint *enfant*. L'architecture de l'app est donc la suivante: app > portal > blueprints liés au portail back-office.
* **supabase_client.py**  -
    1. Crée une fonction `get_exact()` complémentaire à `get_match()` et plus pratique pour accèder à une entrée spécifique grace à un identifiant unique.
    2. Ajoute `return content` à la fonction `create_csv_log()` au cas ou on voudrait accèder à la réponse de Supabase